### PR TITLE
63/implement related removal

### DIFF
--- a/src/main/java/alns/heuristics/RemovalRelated.java
+++ b/src/main/java/alns/heuristics/RemovalRelated.java
@@ -1,0 +1,109 @@
+package alns.heuristics;
+
+import alns.Solution;
+import alns.heuristics.protocols.Destroyer;
+import data.Messages;
+import data.Problem;
+import objects.Order;
+import utils.DistanceCalculator;
+import utils.Helpers;
+
+import java.util.*;
+
+public class RemovalRelated extends Heuristic implements Destroyer {
+
+    public RemovalRelated(String name, boolean destroy, boolean repair) { super(name, destroy, repair); }
+
+    @Override
+    public Solution destroy(Solution solution, int numberOfOrders) {
+        List<List<Order>> orderSequences = Helpers.deepCopy2DList(solution.getOrderSequences());
+        Set<Order> postponedOrders = Helpers.deepCopySet(solution.getPostponedOrders());
+        Set<Order> unplacedOrders = Helpers.deepCopySet(solution.getUnplacedOrders());
+        double rand_parameter = 1;
+
+        if (unplacedOrders.size() > 0) throw new IllegalStateException(Messages.unplacedOrdersNotEmpty);
+
+        while (unplacedOrders.size() == 0) {
+
+            if (unplacedOrders.size() == numberOfOrders) break;
+
+            int rnSequenceIdx = Problem.random.nextInt(orderSequences.size() + 1);
+
+            if (rnSequenceIdx == orderSequences.size() && postponedOrders.size() > 0) {
+                Order orderToRemove = Helpers.removeRandomElementFromSet(postponedOrders);
+                List<Order> ordersToRemove = getOrdersToRemove(orderToRemove);
+                unplacedOrders.addAll(ordersToRemove);
+                postponedOrders.removeAll(ordersToRemove);
+                for (List<Order> orderSequence : orderSequences) orderSequence.removeAll(ordersToRemove);
+                continue;
+            }
+
+            if (rnSequenceIdx == orderSequences.size() || orderSequences.get(rnSequenceIdx).size() == 0) continue;
+
+            int randomOrderNumber = Problem.random.nextInt(orderSequences.get(rnSequenceIdx).size());
+            Order orderToRemove = orderSequences.get(rnSequenceIdx).remove(randomOrderNumber);
+            List<Order> ordersToRemove = getOrdersToRemove(orderToRemove);
+            unplacedOrders.addAll(ordersToRemove);
+            orderSequences.get(rnSequenceIdx).removeAll(ordersToRemove);
+            postponedOrders.removeAll(ordersToRemove);
+        }
+
+        List<Order> unplacedOrdersList = new ArrayList<>(unplacedOrders);
+
+        while (unplacedOrders.size() < numberOfOrders) {
+            Order order = unplacedOrdersList.get(unplacedOrdersList.size() - 1);
+            Order orderToRemove = null;
+            Map<Order, Double> distanceToRemovalOrder = findRelatedRemovals(orderSequences, postponedOrders, order);
+
+            Iterator iterator = distanceToRemovalOrder.entrySet().iterator();
+            while (iterator.hasNext()) {
+                if (Problem.random.nextDouble() > (1 - rand_parameter)) {
+                    Map.Entry distanceToRemovalPair = (Map.Entry) iterator.next();
+                    orderToRemove = (Order) distanceToRemovalPair.getKey();
+                    break;
+                }
+            }
+            List<Order> ordersToRemove = getOrdersToRemove(orderToRemove);
+            unplacedOrders.addAll(ordersToRemove);
+            postponedOrders.removeAll(ordersToRemove);
+            for (List<Order> orderSequence : orderSequences) {
+                for (int orderIdx = 0; orderIdx < orderSequence.size(); orderIdx++) {
+                    if (ordersToRemove.contains(orderSequence.get(orderIdx))) {
+                        orderSequence.remove(orderIdx);
+                    }
+                }
+            }
+            unplacedOrdersList.addAll(ordersToRemove);
+        }
+
+        return new Solution(orderSequences, postponedOrders, unplacedOrders);
+    }
+
+    private Map<Order, Double> findRelatedRemovals(List<List<Order>> orderSequences, Set<Order> postponedOrders, Order order) {
+        Map<Order, Double> distanceToRemovalOrder = new HashMap<>();
+        for (int vesselNumber = 0; vesselNumber < Problem.getNumberOfVessels(); vesselNumber++) {
+            List<Order> orderSequence = orderSequences.get(vesselNumber);
+            List<Order> orderSequenceCopy = Helpers.deepCopyList(orderSequence, true);
+            for (Order orderToRelate : orderSequenceCopy)
+                if (orderToRelate != order) {
+                    double distance = DistanceCalculator.distance(order, orderToRelate, "N");
+                    distanceToRemovalOrder.put(orderToRelate, distance);
+                }
+        }
+
+        Set<Order> copyOfPostponedOrders = Helpers.deepCopySet(postponedOrders);
+        for (Order orderToRelate : copyOfPostponedOrders) {
+            if (orderToRelate != order) {
+                double distance = DistanceCalculator.distance(order, orderToRelate, "N");
+                distanceToRemovalOrder.put(orderToRelate, distance);
+            }
+        }
+
+        LinkedHashMap<Order, Double> sortedDistanceToRemovalOrder = new LinkedHashMap<>();
+        distanceToRemovalOrder.entrySet().stream().sorted(Map.Entry.comparingByValue()).
+                forEachOrdered(entryOrder -> sortedDistanceToRemovalOrder.put(entryOrder.getKey(), entryOrder.getValue()));
+
+        return sortedDistanceToRemovalOrder;
+    }
+
+}

--- a/src/main/java/alns/heuristics/RemovalRelated.java
+++ b/src/main/java/alns/heuristics/RemovalRelated.java
@@ -3,6 +3,7 @@ package alns.heuristics;
 import alns.Solution;
 import alns.heuristics.protocols.Destroyer;
 import data.Messages;
+import data.Parameters;
 import data.Problem;
 import objects.Order;
 import utils.DistanceCalculator;
@@ -19,7 +20,6 @@ public class RemovalRelated extends Heuristic implements Destroyer {
         List<List<Order>> orderSequences = Helpers.deepCopy2DList(solution.getOrderSequences());
         Set<Order> postponedOrders = Helpers.deepCopySet(solution.getPostponedOrders());
         Set<Order> unplacedOrders = Helpers.deepCopySet(solution.getUnplacedOrders());
-        double rand_parameter = 1;
 
         if (unplacedOrders.size() > 0) throw new IllegalStateException(Messages.unplacedOrdersNotEmpty);
 
@@ -57,7 +57,7 @@ public class RemovalRelated extends Heuristic implements Destroyer {
 
             Iterator iterator = distanceToRemovalOrder.entrySet().iterator();
             while (iterator.hasNext()) {
-                if (Problem.random.nextDouble() > (1 - rand_parameter)) {
+                if (Problem.random.nextDouble() > (1 - Parameters.randomParameter)) {
                     Map.Entry distanceToRemovalPair = (Map.Entry) iterator.next();
                     orderToRemove = (Order) distanceToRemovalPair.getKey();
                     break;

--- a/src/main/java/alns/heuristics/RemovalRelated.java
+++ b/src/main/java/alns/heuristics/RemovalRelated.java
@@ -68,11 +68,7 @@ public class RemovalRelated extends Heuristic implements Destroyer {
             unplacedOrders.addAll(ordersToRemove);
             postponedOrders.removeAll(ordersToRemove);
             for (List<Order> orderSequence : orderSequences) {
-                for (int orderIdx = 0; orderIdx < orderSequence.size(); orderIdx++) {
-                    if (ordersToRemove.contains(orderSequence.get(orderIdx))) {
-                        orderSequence.remove(orderIdx);
-                    }
-                }
+                orderSequence.removeIf(ordersToRemove::contains);
             }
             unplacedOrdersList.addAll(ordersToRemove);
         }

--- a/src/main/java/alns/heuristics/RemovalRelated.java
+++ b/src/main/java/alns/heuristics/RemovalRelated.java
@@ -62,6 +62,7 @@ public class RemovalRelated extends Heuristic implements Destroyer {
                     orderToRemove = (Order) distanceToRemovalPair.getKey();
                     break;
                 }
+                iterator.remove();
             }
             List<Order> ordersToRemove = getOrdersToRemove(orderToRemove);
             unplacedOrders.addAll(ordersToRemove);

--- a/src/main/java/data/Parameters.java
+++ b/src/main/java/data/Parameters.java
@@ -18,6 +18,9 @@ public class Parameters {
     public static double startTemperature;
     public static double coolingRate;
 
+    // Random parameter removal methods
+    public static double randomParameter = 0.5;
+
     // Iterations
     public static int totalIterations = 1000;
     public static int maxIterSolution = 20;

--- a/src/test/java/alns/heuristics/RemovalRelatedTest.java
+++ b/src/test/java/alns/heuristics/RemovalRelatedTest.java
@@ -19,7 +19,7 @@ public class RemovalRelatedTest {
     @DisplayName("test RemovalRelated")
     public void removalRelatedTest() {
         Problem.setUpProblem("basicTestData.json", true, 10);
-        Parameters.randomParameter = 1;
+        Parameters.randomParameter = 0;
         RemovalRelated removalRelated = new RemovalRelated("related removal", true, false);
 
         Solution solution = createInitialSolution();

--- a/src/test/java/alns/heuristics/RemovalRelatedTest.java
+++ b/src/test/java/alns/heuristics/RemovalRelatedTest.java
@@ -1,0 +1,73 @@
+package alns.heuristics;
+
+import alns.Solution;
+import alns.SolutionGenerator;
+import data.Problem;
+import objects.Order;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import utils.Helpers;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+public class RemovalRelatedTest {
+
+    @Test
+    @DisplayName("test RemovalRelated")
+    public void removalRelatedTest() {
+        Problem.setUpProblem("basicTestData.json", true, 10);
+        RemovalRelated removalRelated = new RemovalRelated("related removal", true, false);
+        // Setup with randomization parameter equal to 1
+
+        Solution solution = createInitialSolution();
+        testNumberOfRemovals(removalRelated, solution);
+        testNoRemovals(removalRelated, solution);
+        testRemovalsAsExpected(removalRelated, solution);
+    }
+
+    private Solution createInitialSolution() {
+        Solution solution = SolutionGenerator.createSolutionBasicTestData(2, 3);
+        List<Order> charterVoyage = solution.getOrderSequence(2);
+        solution.getPostponedOrders().addAll(charterVoyage.subList(2, charterVoyage.size()));
+        charterVoyage.removeIf(solution.getPostponedOrders()::contains);
+        return solution;
+    }
+
+    private void testNumberOfRemovals(RemovalRelated removalRelated, Solution solution) {
+        int ordersToRemove = 3;
+        int ordersBefore = 0;
+        int ordersAfter = 0;
+        Solution copyOfSolution = Helpers.deepCopySolution(solution);
+        for (List<Order> orderSequence : copyOfSolution.getOrderSequences()) ordersBefore += orderSequence.size();
+        ordersBefore += copyOfSolution.getPostponedOrders().size();
+        Solution partialSolution = removalRelated.destroy(solution, ordersToRemove);
+        for (List<Order> orderSequence : partialSolution.getOrderSequences()) ordersAfter += orderSequence.size();
+        ordersToRemove += partialSolution.getPostponedOrders().size();
+        assertEquals(ordersBefore, ordersAfter + ordersToRemove);
+    }
+
+    private void testNoRemovals(RemovalRelated removalRelated, Solution solution) {
+        Solution partialSolution = removalRelated.destroy(solution, 0);
+        assertEquals(solution, partialSolution);
+    }
+
+    private void testRemovalsAsExpected(RemovalRelated removalRelated, Solution solution) {
+        Solution partialSolution = removalRelated.destroy(solution, 3);
+        Solution expectedSolution = createdExpectedSolutionThree();
+        assertEquals(partialSolution, expectedSolution);
+    }
+
+    private Solution createdExpectedSolutionThree() {
+        List<List<Order>> orderSequences = new ArrayList<>();
+        orderSequences.add(new LinkedList<>());
+        orderSequences.add(new LinkedList<>(Collections.singletonList(Problem.getOrder(2))));
+        orderSequences.add(new LinkedList<>(Arrays.asList(Problem.getOrder(3), Problem.getOrder(4))));
+        Set<Order> postponedOrders = new HashSet<>(Arrays.asList(Problem.getOrder(5), Problem.getOrder(7)));
+        Set<Order> unplacedOrders = new HashSet<>(Arrays.asList(Problem.getOrder(0), Problem.getOrder(6),
+                Problem.getOrder(1)));
+        return new Solution(orderSequences, postponedOrders, unplacedOrders);
+    }
+
+}

--- a/src/test/java/alns/heuristics/RemovalRelatedTest.java
+++ b/src/test/java/alns/heuristics/RemovalRelatedTest.java
@@ -2,6 +2,7 @@ package alns.heuristics;
 
 import alns.Solution;
 import alns.SolutionGenerator;
+import data.Parameters;
 import data.Problem;
 import objects.Order;
 import org.junit.Test;
@@ -18,8 +19,8 @@ public class RemovalRelatedTest {
     @DisplayName("test RemovalRelated")
     public void removalRelatedTest() {
         Problem.setUpProblem("basicTestData.json", true, 10);
+        Parameters.randomParameter = 1;
         RemovalRelated removalRelated = new RemovalRelated("related removal", true, false);
-        // Setup with randomization parameter equal to 1
 
         Solution solution = createInitialSolution();
         testNumberOfRemovals(removalRelated, solution);


### PR DESCRIPTION
- Laget RemovalRelated med tilhørende tester
- FIKSET. En randomization parameter er inkludert for å avgjøre hvilken ordre som skal fjernes. Denne er per nå hardkodet til = 1 i destroy-metoden for å sikre at testene gir riktig resultat. Kan det være en idé å inkludere parameteren i konstruktøren?
