### PR TITLE
118/refactor bfs

### DIFF
--- a/src/main/java/alns/Main.java
+++ b/src/main/java/alns/Main.java
@@ -270,6 +270,7 @@ public class Main {
         double timeElapsed = (System.nanoTime() - startTime) / 1e9;
         System.out.println("Best fitness: " + Main.getBestSolution().getFitness(false));
         System.out.println("Time elapsed: " + timeElapsed + "\n");
+        Main.getBestSolution().printSchedules();
     }
 
     public static void main(String[] args) {

--- a/src/main/java/alns/Main.java
+++ b/src/main/java/alns/Main.java
@@ -10,7 +10,6 @@ import data.Problem;
 import objects.Order;
 import setpartitioning.Data;
 import setpartitioning.Model;
-import subproblem.SubProblem;
 import utils.IO;
 
 import java.util.*;
@@ -271,7 +270,6 @@ public class Main {
         double timeElapsed = (System.nanoTime() - startTime) / 1e9;
         System.out.println("Best fitness: " + Main.getBestSolution().getFitness(false));
         System.out.println("Time elapsed: " + timeElapsed + "\n");
-        Main.getBestSolution().printSchedules();
     }
 
     public static void main(String[] args) {

--- a/src/main/java/data/Parameters.java
+++ b/src/main/java/data/Parameters.java
@@ -26,7 +26,7 @@ public class Parameters {
     public static double rnWorst = 10;
 
     // Concurrency
-    public static boolean parallelHeuristics = false;
+    public static boolean parallelHeuristics = true;
 
     // Iterations
     public static int totalIterations = 1000;

--- a/src/main/java/data/Parameters.java
+++ b/src/main/java/data/Parameters.java
@@ -26,7 +26,7 @@ public class Parameters {
     public static double rnWorst = 10;
 
     // Concurrency
-    public static boolean parallelHeuristics = true;
+    public static boolean parallelHeuristics = false;
 
     // Iterations
     public static int totalIterations = 1000;

--- a/src/main/java/subproblem/SubProblem.java
+++ b/src/main/java/subproblem/SubProblem.java
@@ -19,12 +19,6 @@ public class SubProblem implements Runnable {
     // vesselIdx -> objective value
     public static Map<Integer, Double> vesselToObjective;
 
-    // Cache
-    /*
-    public static Map<Integer, Double> hashToCost;
-    public static Map<Integer, List<Node>> hashToShortestPath;
-     */
-
     public SubProblem(List<Order> orderSequence, int vesselIdx) {
         isOrderSequenceValid(orderSequence);
         isVesselIdxValid(vesselIdx);
@@ -32,13 +26,6 @@ public class SubProblem implements Runnable {
         this.vesselIdx = vesselIdx;
         this.isSpotVessel = Problem.isSpotVessel(vesselIdx);
     }
-
-    /*
-    public static void initializeCache() {
-        hashToCost = new HashMap<>();
-        hashToShortestPath = new HashMap<>();
-    }
-     */
 
     public static void initializeResultsStructure() {
         vesselToObjective = new ConcurrentHashMap<>();
@@ -60,30 +47,7 @@ public class SubProblem implements Runnable {
         tree.generateTree(this.orderSequence, this.isSpotVessel);
         this.shortestPath = tree.findShortestPath();
         this.shortestPathCost = tree.getGlobalBestCost();
-
-        /*
-        boolean cachedSolution = checkCache(this.hashCode());
-        if (!cachedSolution) {
-            Tree tree = new Tree();
-            tree.generateTree(this.orderSequence, this.isSpotVessel);
-            this.shortestPath = tree.findShortestPath();
-            hashToShortestPath.put(this.hashCode(), this.shortestPath);
-            this.shortestPathCost = tree.getGlobalBestCost();
-            hashToCost.put(this.hashCode(), this.shortestPathCost);
-        }
-         */
     }
-
-    /*
-    private boolean checkCache(int hash) {
-        if (hashToCost.containsKey(hash)) {
-            this.shortestPath = hashToShortestPath.get(hash);
-            this.shortestPathCost = hashToCost.get(hash);
-            return true;
-        }
-        return false;
-    }
-     */
 
     public List<Node> getShortestPath() {
         return shortestPath;

--- a/src/main/java/subproblem/Tree.java
+++ b/src/main/java/subproblem/Tree.java
@@ -57,21 +57,17 @@ public class Tree {
         return globalBestCost;
     }
 
-    protected List<Node> getShortestPath() {
-        return shortestPath;
-    }
-
     protected List<Node> findShortestPath() {
         List<Node> queue = initialize();
         while (queue.size() != 0) {
             Node currentNode = ((LinkedList<Node>) queue).removeFirst();
             Set<Node> setOfChildren = currentNode.getChildren();
-            if (currentNode != this.root) updateCurrentBest(currentNode);
             if (setOfChildren.isEmpty()) updateGlobalBest(currentNode);
-            for (Node child : setOfChildren) {
-                if (!child.isVisited()) {
-                    child.setVisited(true);
-                    queue.add(child);
+            for (Node childNode : setOfChildren) {
+                updateChildBest(currentNode, childNode);
+                if (!childNode.isVisited()) {
+                    childNode.setVisited(true);
+                    queue.add(childNode);
                 }
             }
         }
@@ -94,15 +90,13 @@ public class Tree {
         }
     }
 
-    private void updateCurrentBest(Node currentNode) {
-        for (Node parent : currentNode.getParents()) {
-            double currentCost = parent.getBestCost() + parent.getCostOfChild(currentNode);
-            if (currentCost < currentNode.getBestCost()) {
-                currentNode.setBestCost(currentCost);
-                List<Node> path = Helpers.deepCopyList(parent.getBestPath(), false);
-                path.add(currentNode);
-                currentNode.setBestPath(path);
-            }
+    private void updateChildBest(Node currentNode, Node childNode) {
+        double costFromCurrentNode = currentNode.getBestCost() + currentNode.getCostOfChild(childNode);
+        if (costFromCurrentNode < childNode.getBestCost()) {
+            childNode.setBestCost(costFromCurrentNode);
+            List<Node> path = Helpers.deepCopyList(currentNode.getBestPath(), false);
+            path.add(childNode);
+            childNode.setBestPath(path);
         }
     }
 

--- a/src/main/java/subproblem/Tree.java
+++ b/src/main/java/subproblem/Tree.java
@@ -67,9 +67,7 @@ public class Tree {
             Node currentNode = ((LinkedList<Node>) queue).removeFirst();
             Set<Node> setOfChildren = currentNode.getChildren();
             if (currentNode != this.root) updateCurrentBest(currentNode);
-            if (setOfChildren.isEmpty()) {
-                updateGlobalBest(currentNode);
-            }
+            if (setOfChildren.isEmpty()) updateGlobalBest(currentNode);
             for (Node child : setOfChildren) {
                 if (!child.isVisited()) {
                     child.setVisited(true);


### PR DESCRIPTION
findShortestPath oppdaterer en nodes beste kostnad og path når child nodes evalueres, i stedet for at currentNode ser tilbake til parents. Har testet og sett at det gir samme resultater.
Closes #118 