### PR TITLE
16/instance generator

### DIFF
--- a/src/main/java/data/Constants.java
+++ b/src/main/java/data/Constants.java
@@ -4,7 +4,7 @@ public class Constants {
     public static final String ROOT_PATH = System.getProperty("user.dir");
 
     public static String OUTPUT_PATH = ROOT_PATH + "/output/";
-    public static String GENERATOR_PATH = ROOT_PATH + "/src/main/resources/instance/";
+    public static String GENERATOR_PATH = ROOT_PATH + "/src/main/resources/generated/";
 
     public static final String PATH_TO_CONSTANT = "/constant/";
     public static final String PATH_TO_INSTANCE = "/instance/";
@@ -25,11 +25,13 @@ public class Constants {
     public static final String CAPACITY_KEY = "capacity";
     public static final String AVAILABLE_VESSELS_KEY = "available_vessels";
     public static final String FLEET_KEY = "fleet";
+    public static final String SPOT_VESSEL_KEY = "SPOT";
     public static final String RETURN_TIME_KEY = "return_time";
     public static final String PLANNING_PERIOD_KEY = "planning_period_hours";
     public static final String DISCRETIZATION_KEY = "discretization_parameter";
     public static final String WEATHER_SCENARIO_KEY = "weather_scenario";
     public static final String INSTALLATION_ORDERING_KEY = "installation_ordering";
+    public static final String RANDOM_SEED_KEY = "random_seed";
     public static final String MIN_SPEED_KEY = "min_speed";
     public static final String DESIGN_SPEED_KEY = "design_speed";
     public static final String MAX_SPEED_KEY = "max_speed";
@@ -46,10 +48,12 @@ public class Constants {
     public static final String ORDERS_KEY = "orders";
     public static final String ORDER_SIZE_KEY = "size";
     public static final String INSTALLATION_KEY = "installation";
-    public static final String TRANSPORTATION_TYPE_KEY = "transport";
+    public static final String TRANSPORT_KEY = "transport";
     public static final String DELIVERY_VALUE = "delivery";
-    public static final String MANDATORY_VALUE = "mandatory";
+    public static final String PICKUP_VALUE = "pickup";
+    public static final String MANDATORY_KEY = "mandatory";
     public static final String TRUE_VALUE = "True";
+    public static final String FALSE_VALUE = "False";
     public static final String WORST_WEATHER_KEY = "worst_weather_state";
     public static final String SCENARIOS_KEY = "scenarios";
     public static final String SPEED_IMPACT_KEY = "speed_impact";

--- a/src/main/java/data/Constants.java
+++ b/src/main/java/data/Constants.java
@@ -1,6 +1,11 @@
 package data;
 
 public class Constants {
+    public static final String ROOT_PATH = System.getProperty("user.dir");
+
+    public static String OUTPUT_PATH = ROOT_PATH + "/output/";
+    public static String GENERATOR_PATH = ROOT_PATH + "/src/main/resources/instance/";
+
     public static final String PATH_TO_CONSTANT = "/constant/";
     public static final String PATH_TO_INSTANCE = "/instance/";
     public static final String PATH_TO_TEST = "/test/";
@@ -9,14 +14,14 @@ public class Constants {
     public static final String INSTALLATION_FILE = Constants.PATH_TO_CONSTANT + "installations.json";
     public static final String WEATHER_FILE = Constants.PATH_TO_CONSTANT + "weather.json";
 
-    public static String OUTPUT_PATH = System.getProperty("user.dir") + "/output/";
-
     public static final String ID_KEY = "id";
     public static final String OPENING_HOUR_KEY = "opening_hour";
     public static final String CLOSING_HOUR_KEY = "closing_hour";
     public static final String LATITUDE_KEY = "latitude";
     public static final String LONGITUDE_KEY = "longitude";
-    public static final String TYPICAL_DEMAND_KEY = "typical_demand";
+    public static final String STD_DEMAND_MD_KEY = "std_size_MD";
+    public static final String STD_DEMAND_OD_KEY = "std_size_OD";
+    public static final String STD_DEMAND_OP_KEY = "std_size_OP";
     public static final String CAPACITY_KEY = "capacity";
     public static final String AVAILABLE_VESSELS_KEY = "available_vessels";
     public static final String FLEET_KEY = "fleet";

--- a/src/main/java/objects/Installation.java
+++ b/src/main/java/objects/Installation.java
@@ -1,30 +1,21 @@
 package objects;
 
-import java.util.List;
-
 public class Installation implements Comparable<Installation>{
 
-    private int id;
-    private String name;
+    private final int id;
+    private final String name;
+    private final int openingHour;
+    private final int closingHour;
+    private final double latitude;
+    private final double longitude;
 
-    private int openingHour;
-    private int closingHour;
-
-    private double latitude;
-    private double longitude;
-    private List<Double> distances;
-
-    private double typicalDemand;
-
-    public Installation(int id, String name, int openingHour, int closingHour, double latitude, double longitude,
-                        double typicalDemand) {
+    public Installation(int id, String name, int openingHour, int closingHour, double latitude, double longitude) {
         this.id = id;
         this.name = name;
         this.openingHour = openingHour;
         this.closingHour = closingHour;
         this.latitude = latitude;
         this.longitude = longitude;
-        this.typicalDemand = typicalDemand;
     }
 
     public int getId() {
@@ -49,10 +40,6 @@ public class Installation implements Comparable<Installation>{
 
     public double getLongitude() {
         return longitude;
-    }
-
-    public double getTypicalDemand() {
-        return typicalDemand;
     }
 
     @Override

--- a/src/main/java/utils/IO.java
+++ b/src/main/java/utils/IO.java
@@ -95,8 +95,8 @@ public class IO {
             double orderSizeSqm = (double) jsonOrder.get(Constants.ORDER_SIZE_KEY);
             int orderSizeUnits = (int) Math.ceil(orderSizeSqm / Problem.sqmInCargoUnit);
             int installationId = Math.toIntExact((long) jsonOrder.get(Constants.INSTALLATION_KEY));
-            boolean isDelivery = ((jsonOrder.get(Constants.TRANSPORTATION_TYPE_KEY)).equals(Constants.DELIVERY_VALUE));
-            boolean isMandatory = ((jsonOrder.get(Constants.MANDATORY_VALUE)).equals(Constants.TRUE_VALUE));
+            boolean isDelivery = ((jsonOrder.get(Constants.TRANSPORT_KEY)).equals(Constants.DELIVERY_VALUE));
+            boolean isMandatory = ((jsonOrder.get(Constants.MANDATORY_KEY)).equals(Constants.TRUE_VALUE));
             Order order = new Order(orderId, isMandatory, isDelivery, orderSizeUnits, installationId);
             Problem.orders.add(order);
         }

--- a/src/main/java/utils/IO.java
+++ b/src/main/java/utils/IO.java
@@ -53,9 +53,13 @@ public class IO {
                 }
             }
         }
+        writeToFile(Constants.OUTPUT_PATH + Problem.fileName, obj);
+    }
 
+
+    public static void writeToFile(String path, JSONObject obj) {
         try {
-            FileWriter file = new FileWriter(Constants.OUTPUT_PATH + Problem.fileName);
+            FileWriter file = new FileWriter(path);
             file.write(obj.toJSONString());
             file.flush();
             file.close();
@@ -63,6 +67,7 @@ public class IO {
             e.printStackTrace();
         }
     }
+
 
     public static void setUpInstallations() {
         Problem.installations = new ArrayList<>();
@@ -75,9 +80,7 @@ public class IO {
             int closingHour = Math.toIntExact((long) jsonInstallation.get(Constants.CLOSING_HOUR_KEY));
             double latitude = (double) jsonInstallation.get(Constants.LATITUDE_KEY);
             double longitude = (double) jsonInstallation.get(Constants.LONGITUDE_KEY);
-            double typicalDemand = (double) jsonInstallation.get(Constants.TYPICAL_DEMAND_KEY);
-            Installation installation = new Installation(id, name, openingHour, closingHour, latitude, longitude,
-                    typicalDemand);
+            Installation installation = new Installation(id, name, openingHour, closingHour, latitude, longitude);
             Problem.installations.add(installation);
         }
         Collections.sort(Problem.installations);
@@ -186,7 +189,7 @@ public class IO {
         }
     }
 
-    private static JSONObject getJSONObject(String path) {
+    public static JSONObject getJSONObject(String path) {
         JSONParser jsonParser = new JSONParser();
         InputStream inputStream = IO.class.getResourceAsStream(path);
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {

--- a/src/main/java/utils/InstanceGenerator.java
+++ b/src/main/java/utils/InstanceGenerator.java
@@ -1,92 +1,220 @@
 package utils;
 
-import data.Problem;
-import objects.Installation;
-import objects.Order;
+import data.Constants;
+import org.json.simple.JSONObject;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class InstanceGenerator {
 
-    /*
-        - Number of installations (as input)
-        - Get random spatial structure (sample installations randomly from pool of 27)
-        - Apply stochastic rules for assigning order types
-        - Apply stochastic rules for determining order sizes
-        - Choose weather scenario (as input)
-     */
+    private final static JSONObject instance = new JSONObject();
 
-    private final static int seed = 11;  // TODO: Include in instance
+    private final static int seed = 11;
     private final static Random rn = new Random(seed);
     private final static double planningPeriodHours = 80.0;
     private final static double discretizationParameter = 4.0;
     private final static String weatherScenario = "perfect";
     private final static String installationOrdering = "random";
+    private final static int returnTime = 80;
 
     private final static int numberOfInstallations = 5;
+    private final static Map<Integer, List<Double>> instIdToOrderSize = new HashMap<>();
 
-    private final static double MDLower = 0.4;
-    private final static double MDUpper = 0.6;
+    private final static double MDLower = 0.5;
+    private final static double MDUpper = 0.7;
     private final static double ODLower = 0.2;
-    private final static double ODUpper = 0.5;
+    private final static double ODUpper = 0.4;
     private final static double OPLower = 0.2;
-    private final static double OPUpper = 0.5;
+    private final static double OPUpper = 0.4;
 
-    private final static double maxOrderSizeDeviation = 0.2;
+    private final static double sizeDeviation = 0.2;
+
+    private final static Set<Integer> installationsWithOrders = new HashSet<>();
 
     public static void generateInstance() {
+        // Add miscellaneous instance information
+        addMiscInfoToJSON();
 
+        // Choose installations and assign orders
+        mapInstIdToOrderSizes();
         List<Integer> installationIds = drawInstallations();
-        System.out.println(installationIds);
-        assignOrderTypes(installationIds);
+        assignOrders(installationIds);
 
+        // Assign available vessels
+        assignAvailableVessels();
+
+        // Save
+        IO.writeToFile(Constants.GENERATOR_PATH + "test.json", instance);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void addMiscInfoToJSON() {
+        instance.put("planning_period_hours", planningPeriodHours);
+        instance.put("discretization_parameter", discretizationParameter);
+        instance.put("weather_scenario", weatherScenario);
+        instance.put("installation_ordering", installationOrdering);
+        instance.put("random_seed", seed);
+    }
+
+    private static void mapInstIdToOrderSizes() {
+        JSONObject jsonInstallations = IO.getJSONObject(Constants.INSTALLATION_FILE);
+        for (Object key : jsonInstallations.keySet()) {
+            JSONObject jsonInstallation = (JSONObject) jsonInstallations.get(key);
+            int id = Math.toIntExact((long) jsonInstallation.get(Constants.ID_KEY));
+            if (id == 0) continue;
+            double stdSizeMD = (double) jsonInstallation.get(Constants.STD_DEMAND_MD_KEY);
+            double stdSizeOD = (double) jsonInstallation.get(Constants.STD_DEMAND_OD_KEY);
+            double stdSizeOP = (double) jsonInstallation.get(Constants.STD_DEMAND_OP_KEY);
+            instIdToOrderSize.put(id, Arrays.asList(stdSizeMD, stdSizeOD, stdSizeOP));
+        }
     }
 
     private static List<Integer> drawInstallations() {
-        List<Integer> installationIds = new ArrayList<>();
-
-        // TODO: Change to installationIdPool
-        List<Installation> installationPool = Helpers.deepCopyList(Problem.installations, false);
-
-        while (installationIds.size() < numberOfInstallations) {
-            int instIdx = rn.nextInt(installationPool.size());
-            installationIds.add(installationPool.remove(instIdx).getId());
-        }
-
-        return installationIds;
+        List<Integer> installationIds = new ArrayList<>(instIdToOrderSize.keySet());
+        Collections.shuffle(installationIds, rn);
+        return installationIds.subList(0, numberOfInstallations);
     }
 
-    private static void assignOrderTypes(List<Integer> installationIds) {
-        int minMD = (int) Math.ceil(numberOfInstallations * MDLower);
-        int maxMD = (int) Math.floor(numberOfInstallations * MDUpper);
-        List<Integer> range = IntStream.rangeClosed(minMD, maxMD).boxed().collect(Collectors.toList());
-        int numberOfMDs = range.get(rn.nextInt(range.size()));
+    @SuppressWarnings("unchecked")
+    private static void assignOrders(List<Integer> installationIds) {
+        instance.put("orders", new JSONObject());
 
-        int MDOrdersAdded = 0;
-        while (MDOrdersAdded < numberOfMDs) {
-            String mandatory = "True";
-            String transport = "delivery";
-            int installationId = installationIds.remove(rn.nextInt(installationIds.size()));
+        int numberOfMDs = getNumberOfOrdersOfType(MDLower, MDUpper);
+        int numberOfODs = getNumberOfOrdersOfType(ODLower, ODUpper);
+        int numberOfOPs = getNumberOfOrdersOfType(OPLower, OPUpper);
 
-            // TODO: Assign size to order by using installationSizePool
-
-            // TODO: Add order to JSON
-
-            MDOrdersAdded++;
-        }
-
+        addOrdersOfType(numberOfMDs, installationIds, "MD");
+        addOrdersOfType(numberOfODs, installationIds, "OD");
+        addOrdersOfType(numberOfOPs, installationIds, "OP");
     }
 
+    private static int getNumberOfOrdersOfType(double lowerLimit, double upperLimit) {
+        int min = (int) Math.ceil(numberOfInstallations * lowerLimit);
+        int max = (int) Math.floor(numberOfInstallations * upperLimit);
+        List<Integer> range = IntStream.rangeClosed(min, max).boxed().collect(Collectors.toList());
+        return range.get(rn.nextInt(range.size()));
+    }
+
+    private static void addOrdersOfType(int numberOfOrders, List<Integer> installationIds, String orderType) {
+        int ordersAdded = 0;
+        List<Integer> installationIdsCopy = Helpers.deepCopyList(installationIds, false);
+        while (ordersAdded < numberOfOrders) {
+            int id = getInstallationId(installationIdsCopy);
+            installationIdsCopy.remove(Integer.valueOf(id));
+            installationsWithOrders.add(id);
+
+            int sizeIdx = -1;
+            String mandatory = "";
+            String transport = "";
+            switch (orderType) {
+                case "MD":
+                    sizeIdx = 0;
+                    mandatory = "True";
+                    transport = "delivery";
+                    break;
+                case "OD":
+                    sizeIdx = 1;
+                    mandatory = "False";
+                    transport = "delivery";
+                    break;
+                case "OP":
+                    sizeIdx = 2;
+                    mandatory = "False";
+                    transport = "pickup";
+                    break;
+            }
+
+            double orderSize = calculateOrderSize(id, sizeIdx);
+            addOrderToJSON(mandatory, transport, orderSize, id);
+            ordersAdded++;
+        }
+    }
+
+    private static int getInstallationId(List<Integer> installationIds) {
+        List<Integer> installationsWithoutOrders = new ArrayList<>(installationIds);
+        installationsWithoutOrders.removeAll(installationsWithOrders);
+        if (installationsWithoutOrders.isEmpty()) {
+            return installationIds.remove(rn.nextInt(installationIds.size()));
+        } else {
+            return installationsWithoutOrders.remove(rn.nextInt(installationsWithoutOrders.size()));
+        }
+    }
+
+    private static double calculateOrderSize(int id, int sizeIdx) {
+        double stdSize = instIdToOrderSize.get(id).get(sizeIdx);
+        double minSize = stdSize * (1 - sizeDeviation);
+        double maxSize = stdSize * (1 + sizeDeviation);
+        return minSize + (maxSize - minSize) * rn.nextDouble();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void addOrderToJSON(String mandatory, String transport, double orderSize, int id) {
+        String orderIdx = Integer.toString(((JSONObject) instance.get("orders")).size());
+        ((JSONObject) instance.get("orders")).put(orderIdx, new JSONObject());
+        ((JSONObject) ((JSONObject) instance.get("orders")).get(orderIdx)).put("mandatory", mandatory);
+        ((JSONObject) ((JSONObject) instance.get("orders")).get(orderIdx)).put("transport", transport);
+        ((JSONObject) ((JSONObject) instance.get("orders")).get(orderIdx)).put("size", orderSize);
+        ((JSONObject) ((JSONObject) instance.get("orders")).get(orderIdx)).put("installation", id);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assignAvailableVessels() {
+
+        List<Double> orderSizes = countOrderSizes();
+        double MDSize = orderSizes.get(0);
+        double totalSize = orderSizes.get(1);
+
+        instance.put("available_vessels", new JSONObject());
+
+        double fleetCapacity = 0.0;
+        JSONObject jsonFleet = (JSONObject) IO.getJSONObject(Constants.VESSEL_FILE).get("fleet");
+        List<String> vessels = new ArrayList<String>(jsonFleet.keySet());
+        vessels.remove("SPOT");
+        Collections.sort(vessels);
+        for (String vessel : vessels) {
+            JSONObject jsonVessel = (JSONObject) jsonFleet.get(vessel);
+            double capacity = (double) jsonVessel.get("capacity");
+            addVessel(vessel);
+            vessels.remove(vessel);
+            fleetCapacity += capacity;
+            if (fleetCapacity >= MDSize) break;
+        }
+        JSONObject jsonSpot = (JSONObject) jsonFleet.get("SPOT");
+        double capacity = (double) jsonSpot.get("capacity");
+        addVessel("SPOT");
+        fleetCapacity += capacity;
+
+        while (fleetCapacity < totalSize) {
+            String vessel = vessels.get(rn.nextInt(vessels.size()));
+            JSONObject jsonVessel = (JSONObject) jsonFleet.get(vessel);
+            fleetCapacity += (double) jsonVessel.get("capacity");
+            addVessel(vessel);
+        }
+    }
+
+    private static List<Double> countOrderSizes() {
+        double MDSize = 0.0;
+        double totalSize = 0.0;
+        JSONObject orders = (JSONObject) instance.get("orders");
+        for (Object orderIdx : orders.keySet()) {
+            double size = (double) ((JSONObject) orders.get(orderIdx)).get("size");
+            totalSize += size;
+            boolean mandatory = ((JSONObject) orders.get(orderIdx)).get("mandatory").equals("True");
+            boolean delivery = ((JSONObject) orders.get(orderIdx)).get("transport").equals("delivery");
+            if (mandatory && delivery) MDSize += size;
+        }
+        return new ArrayList<>(Arrays.asList(MDSize, totalSize));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void addVessel(String key) {
+        ((JSONObject) instance.get("available_vessels")).put(key, new JSONObject());
+        ((JSONObject) ((JSONObject) instance.get("available_vessels")).get(key)).put("return_time", returnTime);
+    }
 
     public static void main(String[] args) {
-        // TODO: Change such that only installations.json is used
-        Problem.setUpProblem("example_6.json", false, 10);
         InstanceGenerator.generateInstance();
     }
-
 }

--- a/src/main/java/utils/InstanceGenerator.java
+++ b/src/main/java/utils/InstanceGenerator.java
@@ -1,0 +1,92 @@
+package utils;
+
+import data.Problem;
+import objects.Installation;
+import objects.Order;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class InstanceGenerator {
+
+    /*
+        - Number of installations (as input)
+        - Get random spatial structure (sample installations randomly from pool of 27)
+        - Apply stochastic rules for assigning order types
+        - Apply stochastic rules for determining order sizes
+        - Choose weather scenario (as input)
+     */
+
+    private final static int seed = 11;  // TODO: Include in instance
+    private final static Random rn = new Random(seed);
+    private final static double planningPeriodHours = 80.0;
+    private final static double discretizationParameter = 4.0;
+    private final static String weatherScenario = "perfect";
+    private final static String installationOrdering = "random";
+
+    private final static int numberOfInstallations = 5;
+
+    private final static double MDLower = 0.4;
+    private final static double MDUpper = 0.6;
+    private final static double ODLower = 0.2;
+    private final static double ODUpper = 0.5;
+    private final static double OPLower = 0.2;
+    private final static double OPUpper = 0.5;
+
+    private final static double maxOrderSizeDeviation = 0.2;
+
+    public static void generateInstance() {
+
+        List<Integer> installationIds = drawInstallations();
+        System.out.println(installationIds);
+        assignOrderTypes(installationIds);
+
+    }
+
+    private static List<Integer> drawInstallations() {
+        List<Integer> installationIds = new ArrayList<>();
+
+        // TODO: Change to installationIdPool
+        List<Installation> installationPool = Helpers.deepCopyList(Problem.installations, false);
+
+        while (installationIds.size() < numberOfInstallations) {
+            int instIdx = rn.nextInt(installationPool.size());
+            installationIds.add(installationPool.remove(instIdx).getId());
+        }
+
+        return installationIds;
+    }
+
+    private static void assignOrderTypes(List<Integer> installationIds) {
+        int minMD = (int) Math.ceil(numberOfInstallations * MDLower);
+        int maxMD = (int) Math.floor(numberOfInstallations * MDUpper);
+        List<Integer> range = IntStream.rangeClosed(minMD, maxMD).boxed().collect(Collectors.toList());
+        int numberOfMDs = range.get(rn.nextInt(range.size()));
+
+        int MDOrdersAdded = 0;
+        while (MDOrdersAdded < numberOfMDs) {
+            String mandatory = "True";
+            String transport = "delivery";
+            int installationId = installationIds.remove(rn.nextInt(installationIds.size()));
+
+            // TODO: Assign size to order by using installationSizePool
+
+            // TODO: Add order to JSON
+
+            MDOrdersAdded++;
+        }
+
+    }
+
+
+    public static void main(String[] args) {
+        // TODO: Change such that only installations.json is used
+        Problem.setUpProblem("example_6.json", false, 10);
+        InstanceGenerator.generateInstance();
+    }
+
+}

--- a/src/main/java/utils/InstanceGenerator.java
+++ b/src/main/java/utils/InstanceGenerator.java
@@ -11,6 +11,7 @@ public class InstanceGenerator {
 
     private final static JSONObject instance = new JSONObject();
 
+    // Miscellaneous instance information
     private final static int seed = 11;
     private final static Random rn = new Random(seed);
     private final static double planningPeriodHours = 80.0;
@@ -18,20 +19,24 @@ public class InstanceGenerator {
     private final static String weatherScenario = "perfect";
     private final static String installationOrdering = "random";
     private final static int returnTime = 80;
+    private final static String fileName = "test.json";  // Include .json at the end
 
+    // Installation specifics
     private final static int numberOfInstallations = 5;
-    private final static Map<Integer, List<Double>> instIdToOrderSize = new HashMap<>();
 
-    private final static double MDLower = 0.5;
-    private final static double MDUpper = 0.7;
+    // Order specifics
+    private final static double MDLower = 0.5;  // At least MDLower % of the installations must have an MD order
+    private final static double MDUpper = 0.7;  // At most MDUpper % of the installations must have an MD order
     private final static double ODLower = 0.2;
     private final static double ODUpper = 0.4;
     private final static double OPLower = 0.2;
     private final static double OPUpper = 0.4;
+    private final static double sizeDeviation = 0.2;  // Size in [stdSize * (1-sizeDev), stdSize * (1+sizeDev)]
 
-    private final static double sizeDeviation = 0.2;
-
+    // Helper fields used in instance generation
+    private final static Map<Integer, List<Double>> instIdToOrderSize = new HashMap<>();
     private final static Set<Integer> installationsWithOrders = new HashSet<>();
+    private static String finalFleetVessel;
 
     public static void generateInstance() {
         // Add miscellaneous instance information
@@ -46,16 +51,16 @@ public class InstanceGenerator {
         assignAvailableVessels();
 
         // Save
-        IO.writeToFile(Constants.GENERATOR_PATH + "test.json", instance);
+        IO.writeToFile(Constants.GENERATOR_PATH + fileName, instance);
     }
 
     @SuppressWarnings("unchecked")
     private static void addMiscInfoToJSON() {
-        instance.put("planning_period_hours", planningPeriodHours);
-        instance.put("discretization_parameter", discretizationParameter);
-        instance.put("weather_scenario", weatherScenario);
-        instance.put("installation_ordering", installationOrdering);
-        instance.put("random_seed", seed);
+        instance.put(Constants.PLANNING_PERIOD_KEY, planningPeriodHours);
+        instance.put(Constants.DISCRETIZATION_KEY, discretizationParameter);
+        instance.put(Constants.WEATHER_SCENARIO_KEY, weatherScenario);
+        instance.put(Constants.INSTALLATION_ORDERING_KEY, installationOrdering);
+        instance.put(Constants.RANDOM_SEED_KEY, seed);
     }
 
     private static void mapInstIdToOrderSizes() {
@@ -63,7 +68,7 @@ public class InstanceGenerator {
         for (Object key : jsonInstallations.keySet()) {
             JSONObject jsonInstallation = (JSONObject) jsonInstallations.get(key);
             int id = Math.toIntExact((long) jsonInstallation.get(Constants.ID_KEY));
-            if (id == 0) continue;
+            if (id == 0) continue;  // To avoid adding depot
             double stdSizeMD = (double) jsonInstallation.get(Constants.STD_DEMAND_MD_KEY);
             double stdSizeOD = (double) jsonInstallation.get(Constants.STD_DEMAND_OD_KEY);
             double stdSizeOP = (double) jsonInstallation.get(Constants.STD_DEMAND_OP_KEY);
@@ -79,7 +84,7 @@ public class InstanceGenerator {
 
     @SuppressWarnings("unchecked")
     private static void assignOrders(List<Integer> installationIds) {
-        instance.put("orders", new JSONObject());
+        instance.put(Constants.ORDERS_KEY, new JSONObject());
 
         int numberOfMDs = getNumberOfOrdersOfType(MDLower, MDUpper);
         int numberOfODs = getNumberOfOrdersOfType(ODLower, ODUpper);
@@ -111,18 +116,18 @@ public class InstanceGenerator {
             switch (orderType) {
                 case "MD":
                     sizeIdx = 0;
-                    mandatory = "True";
-                    transport = "delivery";
+                    mandatory = Constants.TRUE_VALUE;
+                    transport = Constants.DELIVERY_VALUE;
                     break;
                 case "OD":
                     sizeIdx = 1;
-                    mandatory = "False";
-                    transport = "delivery";
+                    mandatory = Constants.FALSE_VALUE;
+                    transport = Constants.DELIVERY_VALUE;
                     break;
                 case "OP":
                     sizeIdx = 2;
-                    mandatory = "False";
-                    transport = "pickup";
+                    mandatory = Constants.FALSE_VALUE;
+                    transport = Constants.PICKUP_VALUE;
                     break;
             }
 
@@ -151,58 +156,73 @@ public class InstanceGenerator {
 
     @SuppressWarnings("unchecked")
     private static void addOrderToJSON(String mandatory, String transport, double orderSize, int id) {
-        String orderIdx = Integer.toString(((JSONObject) instance.get("orders")).size());
-        ((JSONObject) instance.get("orders")).put(orderIdx, new JSONObject());
-        ((JSONObject) ((JSONObject) instance.get("orders")).get(orderIdx)).put("mandatory", mandatory);
-        ((JSONObject) ((JSONObject) instance.get("orders")).get(orderIdx)).put("transport", transport);
-        ((JSONObject) ((JSONObject) instance.get("orders")).get(orderIdx)).put("size", orderSize);
-        ((JSONObject) ((JSONObject) instance.get("orders")).get(orderIdx)).put("installation", id);
+        String orderIdx = Integer.toString(((JSONObject) instance.get(Constants.ORDERS_KEY)).size());
+        ((JSONObject) instance.get(Constants.ORDERS_KEY)).put(orderIdx, new JSONObject());
+        ((JSONObject) ((JSONObject) instance.get(Constants.ORDERS_KEY)).get(orderIdx)).put(Constants.MANDATORY_KEY,
+                mandatory);
+        ((JSONObject) ((JSONObject) instance.get(Constants.ORDERS_KEY)).get(orderIdx)).put(Constants.TRANSPORT_KEY,
+                transport);
+        ((JSONObject) ((JSONObject) instance.get(Constants.ORDERS_KEY)).get(orderIdx)).put(Constants.ORDER_SIZE_KEY,
+                orderSize);
+        ((JSONObject) ((JSONObject) instance.get(Constants.ORDERS_KEY)).get(orderIdx)).put(Constants.INSTALLATION_KEY
+                , id);
     }
 
     @SuppressWarnings("unchecked")
     private static void assignAvailableVessels() {
 
+        // Count the size occupied by MD orders and by all orders in total
         List<Double> orderSizes = countOrderSizes();
         double MDSize = orderSizes.get(0);
         double totalSize = orderSizes.get(1);
 
-        instance.put("available_vessels", new JSONObject());
+        instance.put(Constants.AVAILABLE_VESSELS_KEY, new JSONObject());
 
+        // Initialize fields
         double fleetCapacity = 0.0;
-        JSONObject jsonFleet = (JSONObject) IO.getJSONObject(Constants.VESSEL_FILE).get("fleet");
+        JSONObject jsonFleet = (JSONObject) IO.getJSONObject(Constants.VESSEL_FILE).get(Constants.FLEET_KEY);
         List<String> vessels = new ArrayList<String>(jsonFleet.keySet());
-        vessels.remove("SPOT");
-        Collections.sort(vessels);
+        vessels.remove(Constants.SPOT_VESSEL_KEY);  // To not add spot vessel twice
+        Collections.sort(vessels);  // To add PSV_1 first, then PSV_2, etc.
+        finalFleetVessel = vessels.get(vessels.size() - 1);  // To break out of loop at the bottom
+
+        // Add enough fleet vessels to cover the MD orders
         for (String vessel : vessels) {
             JSONObject jsonVessel = (JSONObject) jsonFleet.get(vessel);
-            double capacity = (double) jsonVessel.get("capacity");
+            double capacity = (double) jsonVessel.get(Constants.CAPACITY_KEY);
             addVessel(vessel);
             vessels.remove(vessel);
             fleetCapacity += capacity;
             if (fleetCapacity >= MDSize) break;
         }
-        JSONObject jsonSpot = (JSONObject) jsonFleet.get("SPOT");
-        double capacity = (double) jsonSpot.get("capacity");
-        addVessel("SPOT");
+
+        // Add the spot vessel
+        JSONObject jsonSpot = (JSONObject) jsonFleet.get(Constants.SPOT_VESSEL_KEY);
+        double capacity = (double) jsonSpot.get(Constants.CAPACITY_KEY);
+        addVessel(Constants.SPOT_VESSEL_KEY);
         fleetCapacity += capacity;
 
+        // If the fleet (included the spot vessel) can't cover the total demand, add more vessels
         while (fleetCapacity < totalSize) {
             String vessel = vessels.get(rn.nextInt(vessels.size()));
             JSONObject jsonVessel = (JSONObject) jsonFleet.get(vessel);
-            fleetCapacity += (double) jsonVessel.get("capacity");
+            fleetCapacity += (double) jsonVessel.get(Constants.CAPACITY_KEY);
             addVessel(vessel);
+            if (vessel.equals(finalFleetVessel)) break;  // To avoid infinite loop
         }
     }
 
     private static List<Double> countOrderSizes() {
         double MDSize = 0.0;
         double totalSize = 0.0;
-        JSONObject orders = (JSONObject) instance.get("orders");
+        JSONObject orders = (JSONObject) instance.get(Constants.ORDERS_KEY);
         for (Object orderIdx : orders.keySet()) {
-            double size = (double) ((JSONObject) orders.get(orderIdx)).get("size");
+            double size = (double) ((JSONObject) orders.get(orderIdx)).get(Constants.ORDER_SIZE_KEY);
             totalSize += size;
-            boolean mandatory = ((JSONObject) orders.get(orderIdx)).get("mandatory").equals("True");
-            boolean delivery = ((JSONObject) orders.get(orderIdx)).get("transport").equals("delivery");
+            boolean mandatory =
+                    ((JSONObject) orders.get(orderIdx)).get(Constants.MANDATORY_KEY).equals(Constants.TRUE_VALUE);
+            boolean delivery =
+                    ((JSONObject) orders.get(orderIdx)).get(Constants.TRANSPORT_KEY).equals(Constants.DELIVERY_VALUE);
             if (mandatory && delivery) MDSize += size;
         }
         return new ArrayList<>(Arrays.asList(MDSize, totalSize));
@@ -210,8 +230,9 @@ public class InstanceGenerator {
 
     @SuppressWarnings("unchecked")
     private static void addVessel(String key) {
-        ((JSONObject) instance.get("available_vessels")).put(key, new JSONObject());
-        ((JSONObject) ((JSONObject) instance.get("available_vessels")).get(key)).put("return_time", returnTime);
+        ((JSONObject) instance.get(Constants.AVAILABLE_VESSELS_KEY)).put(key, new JSONObject());
+        ((JSONObject) ((JSONObject) instance.get(Constants.AVAILABLE_VESSELS_KEY)).get(key)).put(Constants.RETURN_TIME_KEY,
+                returnTime);
     }
 
     public static void main(String[] args) {

--- a/src/main/java/utils/InstanceGenerator.java
+++ b/src/main/java/utils/InstanceGenerator.java
@@ -36,7 +36,6 @@ public class InstanceGenerator {
     // Helper fields used in instance generation
     private final static Map<Integer, List<Double>> instIdToOrderSize = new HashMap<>();
     private final static Set<Integer> installationsWithOrders = new HashSet<>();
-    private static String finalFleetVessel;
 
     public static void generateInstance() {
         // Add miscellaneous instance information
@@ -184,7 +183,7 @@ public class InstanceGenerator {
         List<String> vessels = new ArrayList<String>(jsonFleet.keySet());
         vessels.remove(Constants.SPOT_VESSEL_KEY);  // To not add spot vessel twice
         Collections.sort(vessels);  // To add PSV_1 first, then PSV_2, etc.
-        finalFleetVessel = vessels.get(vessels.size() - 1);  // To break out of loop at the bottom
+        String finalFleetVessel = vessels.get(vessels.size() - 1);  // To break out of loop at the bottom
 
         // Add enough fleet vessels to cover the MD orders
         for (String vessel : vessels) {

--- a/src/main/resources/constant/installations.json
+++ b/src/main/resources/constant/installations.json
@@ -5,7 +5,9 @@
     "closing_hour": 24,
     "latitude": 60.8621,
     "longitude": 4.7126,
-    "typical_demand": 0.0
+    "std_size_MD": 0.0,
+    "std_size_OD": 0.0,
+    "std_size_OP": 0.0
   },
   "TRO": {
     "id": 1,
@@ -13,7 +15,9 @@
     "closing_hour": 24,
     "latitude": 60.6456,
     "longitude": 3.7264,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "TRB": {
     "id": 2,
@@ -21,7 +25,9 @@
     "closing_hour": 19,
     "latitude": 60.77,
     "longitude": 3.50,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "TRC": {
     "id": 3,
@@ -29,7 +35,9 @@
     "closing_hour": 19,
     "latitude": 60.88,
     "longitude": 3.60,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "CPR": {
     "id": 4,
@@ -37,7 +45,9 @@
     "closing_hour": 24,
     "latitude": 60.74,
     "longitude": 3.61,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "SEN": {
     "id": 5,
@@ -45,7 +55,9 @@
     "closing_hour": 24,
     "latitude": 60.95,
     "longitude": 3.58,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "SDO": {
     "id": 6,
@@ -53,7 +65,9 @@
     "closing_hour": 24,
     "latitude": 60.85,
     "longitude": 3.62,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "SEQ": {
     "id": 7,
@@ -61,7 +75,9 @@
     "closing_hour": 24,
     "latitude": 60.89,
     "longitude": 3.67,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "OSE": {
     "id": 8,
@@ -69,7 +85,9 @@
     "closing_hour": 24,
     "latitude": 60.48,
     "longitude": 2.82,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "OSB": {
     "id": 9,
@@ -77,7 +95,9 @@
     "closing_hour": 24,
     "latitude": 60.48,
     "longitude": 2.82,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "OSC": {
     "id": 10,
@@ -85,7 +105,9 @@
     "closing_hour": 24,
     "latitude": 60.60,
     "longitude": 2.77,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "OSO": {
     "id": 11,
@@ -93,7 +115,9 @@
     "closing_hour": 24,
     "latitude": 60.70,
     "longitude": 2.93,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "SSC": {
     "id": 12,
@@ -101,7 +125,9 @@
     "closing_hour": 24,
     "latitude": 60.70,
     "longitude": 2.93,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "OSS": {
     "id": 13,
@@ -109,7 +135,9 @@
     "closing_hour": 24,
     "latitude": 60.38,
     "longitude": 2.79,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "DSD": {
     "id": 14,
@@ -117,7 +145,9 @@
     "closing_hour": 24,
     "latitude": 60.08,
     "longitude": 2.63,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "KVB": {
     "id": 15,
@@ -125,7 +155,9 @@
     "closing_hour": 24,
     "latitude": 61.07,
     "longitude": 2.50,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "VMO": {
     "id": 16,
@@ -133,7 +165,9 @@
     "closing_hour": 24,
     "latitude": 61.04,
     "longitude": 2.34,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "WEL": {
     "id": 17,
@@ -141,7 +175,9 @@
     "closing_hour": 24,
     "latitude": 61.04,
     "longitude": 2.34,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "VFB": {
     "id": 18,
@@ -149,7 +185,9 @@
     "closing_hour": 24,
     "latitude": 60.78,
     "longitude": 2.89,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "WEP": {
     "id": 19,
@@ -157,7 +195,9 @@
     "closing_hour": 24,
     "latitude": 60.85,
     "longitude": 2.65,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "HUL": {
     "id": 20,
@@ -165,7 +205,9 @@
     "closing_hour": 24,
     "latitude": 60.85,
     "longitude": 2.65,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "STA": {
     "id": 21,
@@ -173,7 +215,9 @@
     "closing_hour": 19,
     "latitude": 61.25,
     "longitude": 1.85,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "STB": {
     "id": 22,
@@ -181,7 +225,9 @@
     "closing_hour": 24,
     "latitude": 61.20,
     "longitude": 1.82,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "STC": {
     "id": 23,
@@ -189,7 +235,9 @@
     "closing_hour": 24,
     "latitude": 61.29,
     "longitude": 1.90,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "GFA": {
     "id": 24,
@@ -197,7 +245,9 @@
     "closing_hour": 24,
     "latitude": 61.17,
     "longitude": 2.18,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "GFB": {
     "id": 25,
@@ -205,7 +255,9 @@
     "closing_hour": 24,
     "latitude": 61.20,
     "longitude": 2.20,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "GFC": {
     "id": 26,
@@ -213,7 +265,9 @@
     "closing_hour": 24,
     "latitude": 61.20,
     "longitude": 2.27,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   },
   "SOD": {
     "id": 27,
@@ -221,6 +275,8 @@
     "closing_hour": 24,
     "latitude": 60.90,
     "longitude": 3.81,
-    "typical_demand": 100.0
+    "std_size_MD": 100.0,
+    "std_size_OD": 100.0,
+    "std_size_OP": 100.0
   }
 }

--- a/src/main/resources/generated/test.json
+++ b/src/main/resources/generated/test.json
@@ -1,0 +1,53 @@
+{
+  "random_seed": 11,
+  "available_vessels": {
+    "SPOT": {
+      "return_time": 80
+    },
+    "PSV_1": {
+      "return_time": 80
+    }
+  },
+  "weather_scenario": "perfect",
+  "planning_period_hours": 80.0,
+  "orders": {
+    "0": {
+      "size": 104.27320224391153,
+      "installation": 15,
+      "transport": "delivery",
+      "mandatory": "True"
+    },
+    "1": {
+      "size": 111.15158518931267,
+      "installation": 17,
+      "transport": "delivery",
+      "mandatory": "True"
+    },
+    "2": {
+      "size": 87.30548159971552,
+      "installation": 22,
+      "transport": "delivery",
+      "mandatory": "True"
+    },
+    "3": {
+      "size": 91.78614909666727,
+      "installation": 19,
+      "transport": "delivery",
+      "mandatory": "False"
+    },
+    "4": {
+      "size": 108.5278957056378,
+      "installation": 27,
+      "transport": "pickup",
+      "mandatory": "False"
+    },
+    "5": {
+      "size": 83.2041592973672,
+      "installation": 17,
+      "transport": "pickup",
+      "mandatory": "False"
+    }
+  },
+  "installation_ordering": "random",
+  "discretization_parameter": 4.0
+}


### PR DESCRIPTION
Instansgenerator laget slik at...
- Et antall installasjoner og grenser for hvor mange av disse som skal ha de ulike ordretypene tas inn
- Antallet installasjoner velges helt tilfeldig (ettersom Kjetil tenkte vi kun trengte én instans per installasjonsantall)
- Deretter får disse ordre etter prosentregler (i.e. minst 50% av inst skal ha MD, maks 70%)
- Ordrestørrelsen velges uniformt i intervallet [standard * (1 - deviation), standard * (1 + deviation)]
- Antall vessels settes slik at fleet vessels dekker MD. Deretter legger vi på SPOT og ser om alt demand dekkes. Dersom ikke alt dekkes legger vi på fleet vessels til alt demand dekkes. Akkurat hva som er mest fornuftig her er jeg ikke helt sikker på, men det er lett å endre
- Ellers lagres det litt misc info om instansen

Ellers har det skjedd litt refaktorering ifm. instansgeneratoren. Før denne PR'en har jeg også kjørt gjennom noen andre ting, kan forklare det separat. 

Closes #16 